### PR TITLE
Improve piwik compatibility and deployment fixes.

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -113,6 +113,23 @@ http {
         #include apps/piwik/fcgi_piwik_long_cache.conf;
     }
 
+    ## Relay all piwik.php requests to fastcgi. including for improved compatibility with some framework plugins, etc. that still reference "piwik" vs. "matomo".
+    location = /piwik.php {
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param HTTPS on;
+        fastcgi_param REMOTE_ADDR $http_x_forwarded_for;
+        #Avoid sending the security headers twice
+        fastcgi_param modHeadersAvailable true;
+        fastcgi_param front_controller_active true;
+        fastcgi_pass php-handler;
+        fastcgi_intercept_errors on;
+        fastcgi_request_buffering off;
+        #include apps/piwik/fcgi_piwik_long_cache.conf;
+    }
+
     ## Any other attempt to access PHP files returns a 404.
     location ~* ^.+\.php$ {
         return 404;

--- a/openshift/templates/matomo-db/matomo-db-deploy.json
+++ b/openshift/templates/matomo-db/matomo-db-deploy.json
@@ -293,7 +293,7 @@
           "description": "Username for MariaDB user that will be used for accessing the database.  Needs to be base64 encoded/",
           "required": true,
           "generate": "expression",
-          "from": "[a-zA-Z_][a-zA-Z0-9_]{10}"
+          "from": "[a-zA-Z0-9]{10}"
       },
       {
           "name": "MYSQL_PASSWORD",
@@ -301,7 +301,7 @@
           "description": "Password for the MariaDB connection user.  Needs to be base64 encoded/",
           "required": true,
           "generate": "expression",
-          "from": "[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}"
+          "from": "[a-zA-Z0-9]{10}"
       },
       {
           "name": "MYSQL_ROOT_PASSWORD",
@@ -309,7 +309,7 @@
           "description": "Password for the MariaDB administrative account.  Needs to be base64 encoded.",
           "required": true,
           "generate": "expression",
-          "from": "[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}"
+          "from": "[a-zA-Z0-9]{16}"
       },
       {
           "name": "MOUNT_PATH",

--- a/openshift/templates/matomo-proxy/matomo-proxy-build.json
+++ b/openshift/templates/matomo-proxy/matomo-proxy-build.json
@@ -69,7 +69,7 @@
       "displayName": "Git Repo URL",
       "description": "The URL to your GIT repo.",
       "required": true,
-      "value": "https://github.com/bcgov/matomo-openshift.git"
+      "value": "https://github.com/bcdevops/matomo-openshift.git"
     },
     {
       "name": "GIT_REF",


### PR DESCRIPTION
- Improve compatibility with tools that still refer to piwik (vs. matomo) by updating nginx config for `matomo-proxy`.
- Fix a bug that was causing invalid credentials to be created for the `matomo-db` component.
- Fix the default GitHub org for the `matomo-proxy` component so it correctly points to `BCDevOps` and uses won't need to correct it.