### PR TITLE
Use netapp-file-standard, upgrade Matomo version

### DIFF
--- a/openshift/templates/matomo-db/matomo-db-deploy.json
+++ b/openshift/templates/matomo-db/matomo-db-deploy.json
@@ -341,7 +341,7 @@
     {
       "name": "PERSISTENT_VOLUME_CLASS",
       "displayName": "Persistent Volume Class name",
-      "description": "The class of the volume; gluster-file, gluster-block, gluster-file-db, netapp-file-standard, netapp-block-standard",
+      "description": "The class of the volume; gluster-file, gluster-block, netapp-file-standard, netapp-file-standard, netapp-block-standard",
       "required": false,
       "value": "netapp-file-standard"
     },

--- a/openshift/templates/matomo/matomo-build.json
+++ b/openshift/templates/matomo/matomo-build.json
@@ -55,7 +55,7 @@
       "displayName": "Output Image Tag",
       "description": "The tag given to the built image.",
       "required": true,
-      "value": "3.13.5-fpm"
+      "value": "3.14.1-fpm"
     },
     {
       "name": "SOURCE_IMAGE_KIND",
@@ -76,7 +76,7 @@
       "displayName": "Source Image Tag",
       "description": "The tag of the source image.",
       "required": true,
-      "value": "3.13.5-fpm"
+      "value": "3.14.1-fpm"
     }
   ]
 }

--- a/openshift/templates/matomo/matomo-deploy.json
+++ b/openshift/templates/matomo/matomo-deploy.json
@@ -332,7 +332,7 @@
     {
       "name": "PERSISTENT_VOLUME_CLASS",
       "displayName": "Persistent Volume Class name",
-      "description": "The class of the volume; gluster-file, gluster-block, gluster-file-db, netapp-file-standard, netapp-block-standard",
+      "description": "The class of the volume; gluster-file, gluster-block, netapp-file-standard, netapp-file-standard, netapp-block-standard",
       "required": false,
       "value": "netapp-file-standard"
     },


### PR DESCRIPTION
DB persistent storage has been upgraded, the storage for the matomo service has not (yet) been upgraded - I can do that if necessary.

Matomo has been upgraded to the latest stable version as well, deployment already updated in OpenShift